### PR TITLE
Update the class method of default placeholder color

### DIFF
--- a/UITextView+Placeholder/UITextView+Placeholder.m
+++ b/UITextView+Placeholder/UITextView+Placeholder.m
@@ -48,7 +48,7 @@
 #pragma mark `defaultPlaceholderColor`
 
 + (UIColor *)defaultPlaceholderColor {
-    __block UIColor *color = nil;
+    static UIColor *color = nil;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
         UITextField *textField = [[UITextField alloc] init];


### PR DESCRIPTION
Use static variable for the default placeholder color so that it won't be nil when the class method is called multiple times.
