### PR TITLE
[iOS 6] Use default values for NSTextContainer related properties.

### DIFF
--- a/UITextView+Placeholder/UITextView+Placeholder.m
+++ b/UITextView+Placeholder/UITextView+Placeholder.m
@@ -150,10 +150,27 @@
     self.placeholderLabel.font = self.font;
     self.placeholderLabel.textAlignment = self.textAlignment;
 
-    CGFloat x = self.textContainer.lineFragmentPadding + self.textContainerInset.left;
-    CGFloat y = self.textContainerInset.top;
-    CGFloat width = (CGRectGetWidth(self.bounds) - x - self.textContainer.lineFragmentPadding
-                     - self.textContainerInset.right);
+    // `NSTextContainer` is available since iOS 7
+    CGFloat lineFragmentPadding;
+    UIEdgeInsets textContainerInset;
+
+#pragma deploymate push "ignored-api-availability"
+    // iOS 7+
+    if (NSFoundationVersionNumber > NSFoundationVersionNumber_iOS_6_1) {
+        lineFragmentPadding = self.textContainer.lineFragmentPadding;
+        textContainerInset = self.textContainerInset;
+    }
+#pragma deploymate pop
+
+    // iOS 6
+    else {
+        lineFragmentPadding = 5;
+        textContainerInset = UIEdgeInsetsMake(8, 0, 8, 0);
+    }
+
+    CGFloat x = lineFragmentPadding + textContainerInset.left;
+    CGFloat y = textContainerInset.top;
+    CGFloat width = CGRectGetWidth(self.bounds) - x - lineFragmentPadding - textContainerInset.right;
     CGFloat height = [self.placeholderLabel sizeThatFits:CGSizeMake(width, 0)].height;
     self.placeholderLabel.frame = CGRectMake(x, y, width, height);
 }

--- a/UITextViewPlaceholderDemo/UITextViewPlaceholderDemo/ViewController.m
+++ b/UITextViewPlaceholderDemo/UITextViewPlaceholderDemo/ViewController.m
@@ -19,7 +19,6 @@
     textView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
     textView.placeholder = @"Are you sure you don\'t want to reconsider? Could you tell us why you wish to leave StyleShare? Your opinion helps us improve StyleShare into a better place for fashionistas from all around the world. We are always listening to our users. Help us improve!";
     textView.font = [UIFont systemFontOfSize:15];
-    textView.textContainerInset = UIEdgeInsetsMake(10, 5, 10, 5);
     [self.view addSubview:textView];
 }
 


### PR DESCRIPTION
- `NSTextContainer` is available since iOS 7.
- Use default values for `lineFragmentPadding` and `textContainerInset` in iOS 6.
- Related issue: #6
