### PR TITLE
Don't try to removeObserver if we are not yet observing.

### DIFF
--- a/UITextView+Placeholder/UITextView+Placeholder.m
+++ b/UITextView+Placeholder/UITextView+Placeholder.m
@@ -39,12 +39,15 @@
 
 - (void)swizzledDealloc {
     [[NSNotificationCenter defaultCenter] removeObserver:self];
-    for (NSString *key in self.class.observingKeys) {
-        @try {
-            [self removeObserver:self forKeyPath:key];
-        }
-        @catch (NSException *exception) {
-            // Do nothing
+    UILabel *label = objc_getAssociatedObject(self, @selector(placeholderLabel));
+    if (label) {
+        for (NSString *key in self.class.observingKeys) {
+            @try {
+                [self removeObserver:self forKeyPath:key];
+            }
+            @catch (NSException *exception) {
+                // Do nothing
+            }
         }
     }
     [self swizzledDealloc];


### PR DESCRIPTION
If you have and "All Exceptions" breakpoint set it stop in the @try block for every uitextview. We should only try to remove the observer if we are observing.

I guess a better method would be to set a cleanup block on the instance when we do the observing, but this does the trick for me at the moment.