### PR TITLE
modify the KVO function

### DIFF
--- a/Demo/Base.lproj/LaunchScreen.storyboard
+++ b/Demo/Base.lproj/LaunchScreen.storyboard
@@ -1,7 +1,12 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="8150" systemVersion="15A204g" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" initialViewController="01J-lp-oVM">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11542" systemVersion="16B2555" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="8122"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11524"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--View Controller-->
@@ -13,15 +18,21 @@
                         <viewControllerLayoutGuide type="bottom" id="xb3-aO-Qok"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <animations/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                        <subviews>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Q7N-eY-a8e">
+                                <rect key="frame" x="160" y="617" width="55" height="30"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="Remove"/>
+                            </button>
+                        </subviews>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     </view>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="53" y="375"/>
+            <point key="canvasLocation" x="-57" y="87"/>
         </scene>
     </scenes>
 </document>

--- a/Demo/Base.lproj/Main.storyboard
+++ b/Demo/Base.lproj/Main.storyboard
@@ -1,25 +1,91 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6211" systemVersion="14A298i" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="BYZ-38-t0r">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11542" systemVersion="16B2555" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="retina5_5" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6204"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11524"/>
+        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--View Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="ViewController" customModuleProvider="" sceneMemberID="viewController">
+                <viewController id="BYZ-38-t0r" customClass="ViewController" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="y3c-jy-aDJ"/>
                         <viewControllerLayoutGuide type="bottom" id="wfy-db-euE"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="736"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                        <subviews>
+                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="pKd-Yi-7XS">
+                                <rect key="frame" x="20" y="20" width="374" height="200"/>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="200" id="bLq-sD-wlC"/>
+                                </constraints>
+                                <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</string>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                            </textView>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="DuC-E4-FCK">
+                                <rect key="frame" x="40" y="250" width="98" height="30"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="30" id="wHE-BG-d7C"/>
+                                </constraints>
+                                <state key="normal" title="Change Font"/>
+                                <connections>
+                                    <action selector="onChangeFont:" destination="BYZ-38-t0r" eventType="touchUpInside" id="wVz-B6-im2"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Obc-BH-hIM">
+                                <rect key="frame" x="158" y="250" width="98" height="30"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="30" id="eHG-IF-BiM"/>
+                                </constraints>
+                                <state key="normal" title="Change Color"/>
+                                <connections>
+                                    <action selector="onChangeColor:" destination="BYZ-38-t0r" eventType="touchUpInside" id="yTi-c7-xmH"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="c3X-Um-ntK">
+                                <rect key="frame" x="276" y="250" width="98" height="30"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="30" id="ahJ-sW-GLH"/>
+                                </constraints>
+                                <state key="normal" title="Test Release"/>
+                                <connections>
+                                    <action selector="onTextRemove:" destination="BYZ-38-t0r" eventType="touchUpInside" id="7Q4-5i-EOL"/>
+                                </connections>
+                            </button>
+                        </subviews>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <constraints>
+                            <constraint firstItem="DuC-E4-FCK" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leadingMargin" constant="20" id="2ui-Bf-T6Z"/>
+                            <constraint firstItem="Obc-BH-hIM" firstAttribute="top" secondItem="y3c-jy-aDJ" secondAttribute="bottom" constant="230" id="54M-E0-lTh"/>
+                            <constraint firstItem="DuC-E4-FCK" firstAttribute="top" secondItem="y3c-jy-aDJ" secondAttribute="bottom" constant="230" id="6gc-XM-SjC"/>
+                            <constraint firstItem="pKd-Yi-7XS" firstAttribute="top" secondItem="y3c-jy-aDJ" secondAttribute="bottom" id="8mX-wt-9b3"/>
+                            <constraint firstItem="c3X-Um-ntK" firstAttribute="top" secondItem="y3c-jy-aDJ" secondAttribute="bottom" constant="230" id="KuS-2Y-Tcc"/>
+                            <constraint firstItem="pKd-Yi-7XS" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leadingMargin" id="Ltu-lm-HUL"/>
+                            <constraint firstAttribute="trailingMargin" secondItem="c3X-Um-ntK" secondAttribute="trailing" constant="20" id="TE9-dB-ckx"/>
+                            <constraint firstItem="pKd-Yi-7XS" firstAttribute="trailing" secondItem="8bC-Xf-vdC" secondAttribute="trailingMargin" id="UUX-6W-dqv"/>
+                            <constraint firstItem="DuC-E4-FCK" firstAttribute="width" secondItem="Obc-BH-hIM" secondAttribute="width" id="ggf-Dl-81O"/>
+                            <constraint firstItem="Obc-BH-hIM" firstAttribute="leading" secondItem="DuC-E4-FCK" secondAttribute="trailing" constant="20" id="jnV-XC-Lia"/>
+                            <constraint firstItem="c3X-Um-ntK" firstAttribute="leading" secondItem="Obc-BH-hIM" secondAttribute="trailing" constant="20" id="nLw-rn-lqE"/>
+                            <constraint firstItem="Obc-BH-hIM" firstAttribute="width" secondItem="c3X-Um-ntK" secondAttribute="width" id="qos-ne-z5G"/>
+                        </constraints>
                     </view>
+                    <connections>
+                        <outlet property="textView" destination="pKd-Yi-7XS" id="YOv-pt-Kkb"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
+            <point key="canvasLocation" x="-386.95652173913044" y="-200.54347826086959"/>
         </scene>
     </scenes>
 </document>

--- a/Demo/ViewController.m
+++ b/Demo/ViewController.m
@@ -23,21 +23,38 @@
 #import "ViewController.h"
 #import <UITextView_Placeholder/UITextView+Placeholder.h>
 
+@interface ViewController()
+
+@property (weak, nonatomic) IBOutlet UITextView *textView;
+
+
+@end
+
 @implementation ViewController
 
 - (void)viewDidLoad {
     [super viewDidLoad];
 
-    UITextView *textView = [[UITextView alloc] init];
-    textView.frame = CGRectMake(0, 20, CGRectGetWidth(self.view.bounds), CGRectGetHeight(self.view.bounds));
-    textView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
-    textView.placeholder = @"Are you sure you don\'t want to reconsider? Could you tell us why you wish to leave StyleShare? Your opinion helps us improve StyleShare into a better place for fashionistas from all around the world. We are always listening to our users. Help us improve!";
+    self.textView.placeholder = @"Are you sure you don\'t want to reconsider? Could you tell us why you wish to leave StyleShare? Your opinion helps us improve StyleShare into a better place for fashionistas from all around the world. We are always listening to our users. Help us improve!";
+    self.textView.placeholderLabel.textAlignment = NSTextAlignmentCenter;
     NSDictionary *attrs = @ {
         NSFontAttributeName: [UIFont boldSystemFontOfSize:20],
     };
-    textView.attributedText = [[NSAttributedString alloc] initWithString:@"Hi" attributes:attrs];
-    textView.font = [UIFont systemFontOfSize:15];
-    [self.view addSubview:textView];
+    self.textView.attributedText = [[NSAttributedString alloc] initWithString:@"Hi" attributes:attrs];
+    self.textView.font = [UIFont systemFontOfSize:15];
+    [self.view addSubview:self.textView];
+}
+
+- (IBAction)onTextRemove:(id)sender {
+    [self.textView removeFromSuperview];
+}
+
+- (IBAction)onChangeFont:(id)sender {
+    self.textView.font = [UIFont systemFontOfSize:30];
+}
+
+- (IBAction)onChangeColor:(id)sender {
+    self.textView.textColor = [UIColor redColor];
 }
 
 @end

--- a/Sources/UITextView+Placeholder.m
+++ b/Sources/UITextView+Placeholder.m
@@ -23,32 +23,89 @@
 #import <objc/runtime.h>
 #import "UITextView+Placeholder.h"
 
+#pragma mark - `observingKeys`
+
+@interface DWTextViewEventObserver : NSObject
+
+@property (copy, nonatomic) void (^execution)(BOOL fontChanged);
+// can't use weak, because weak before UITextView object dealloc, it will set all weak reference to nil
+// it will make our removeObserver failed to remove.
+@property (unsafe_unretained, nonatomic) UITextView *target;
+
+@end
+
+@implementation DWTextViewEventObserver
+
++ (void)observe:(UITextView *)target then:(void (^)(BOOL fontChanged))exec {
+    DWTextViewEventObserver *monitor = [[DWTextViewEventObserver alloc] init];
+    monitor.execution = exec;
+    monitor.target = target;
+    [monitor observeEvents];
+    int randomKey;
+    // It is true that swizzle method of dealloc in NSObject Category can do the same thing, but that will cause method polluted!
+    objc_setAssociatedObject(target, &randomKey, monitor, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
+#pragma mark - LifeCycle
++ (NSArray *)observingKeys {
+    return @[@"attributedText",
+             @"bounds",
+             @"font",
+             @"frame",
+             @"text",
+             @"textAlignment",
+             @"textContainerInset"];
+}
+
+- (void)dealloc {
+    [self releaseObserveKeys];
+}
+
+- (void)observeEvents {
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(updatePlaceholderLabel)
+                                                 name:UITextViewTextDidChangeNotification
+                                               object:self.target];
+    
+    for (NSString *key in self.class.observingKeys) {
+        [self.target addObserver:self forKeyPath:key options:NSKeyValueObservingOptionNew context:nil];
+    }
+}
+
+- (void)updatePlaceholderLabel {
+    if (self.execution) {
+        self.execution(NO);
+    }
+}
+
+- (void)observeValueForKeyPath:(NSString *)keyPath
+                      ofObject:(id)object
+                        change:(NSDictionary *)change
+                       context:(void *)context
+{
+    if (self.execution) {
+        BOOL updateFont = [keyPath isEqualToString:@"font"] && change[NSKeyValueChangeNewKey] != nil;
+        self.execution(updateFont);
+    }
+}
+
+- (void)releaseObserveKeys {
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
+    for (NSString *key in self.class.observingKeys) {
+        @try {
+            [self.target removeObserver:self forKeyPath:key context:nil];
+        }
+        @catch (NSException *exception) {
+            // Do nothing
+        }
+    }
+}
+
+@end
+
 @implementation UITextView (Placeholder)
 
 #pragma mark - Swizzle Dealloc
-
-+ (void)load {
-    // is this the best solution?
-    method_exchangeImplementations(class_getInstanceMethod(self.class, NSSelectorFromString(@"dealloc")),
-                                   class_getInstanceMethod(self.class, @selector(swizzledDealloc)));
-}
-
-- (void)swizzledDealloc {
-    [[NSNotificationCenter defaultCenter] removeObserver:self];
-    UILabel *label = objc_getAssociatedObject(self, @selector(placeholderLabel));
-    if (label) {
-        for (NSString *key in self.class.observingKeys) {
-            @try {
-                [self removeObserver:self forKeyPath:key];
-            }
-            @catch (NSException *exception) {
-                // Do nothing
-            }
-        }
-    }
-    [self swizzledDealloc];
-}
-
 
 #pragma mark - Class Methods
 #pragma mark `defaultPlaceholderColor`
@@ -64,9 +121,6 @@
     return color;
 }
 
-
-#pragma mark - `observingKeys`
-
 + (NSArray *)observingKeys {
     return @[@"attributedText",
              @"bounds",
@@ -76,7 +130,6 @@
              @"textAlignment",
              @"textContainerInset"];
 }
-
 
 #pragma mark - Properties
 #pragma mark `placeholderLabel`
@@ -98,14 +151,13 @@
         [self updatePlaceholderLabel];
         self.needsUpdateFont = NO;
 
-        [[NSNotificationCenter defaultCenter] addObserver:self
-                                                 selector:@selector(updatePlaceholderLabel)
-                                                     name:UITextViewTextDidChangeNotification
-                                                   object:self];
-
-        for (NSString *key in self.class.observingKeys) {
-            [self addObserver:self forKeyPath:key options:NSKeyValueObservingOptionNew context:nil];
-        }
+        __weak typeof(self) weakSelf = self;
+        [DWTextViewEventObserver observe:self then:^(BOOL fontChanged) {
+            if (fontChanged) {
+                weakSelf.needsUpdateFont = fontChanged;
+            }
+            [weakSelf updatePlaceholderLabel];
+        }];
     }
     return label;
 }
@@ -141,7 +193,6 @@
     self.placeholderLabel.textColor = placeholderColor;
 }
 
-
 #pragma mark `needsUpdateFont`
 
 - (BOOL)needsUpdateFont {
@@ -153,21 +204,7 @@
 }
 
 
-#pragma mark - KVO
-
-- (void)observeValueForKeyPath:(NSString *)keyPath
-                      ofObject:(id)object
-                        change:(NSDictionary *)change
-                       context:(void *)context {
-    if ([keyPath isEqualToString:@"font"]) {
-        self.needsUpdateFont = (change[NSKeyValueChangeNewKey] != nil);
-    }
-    [self updatePlaceholderLabel];
-}
-
-
 #pragma mark - Update
-
 - (void)updatePlaceholderLabel {
     if (self.text.length) {
         [self.placeholderLabel removeFromSuperview];
@@ -180,6 +217,7 @@
         self.placeholderLabel.font = self.font;
         self.needsUpdateFont = NO;
     }
+
     self.placeholderLabel.textAlignment = self.textAlignment;
 
     // `NSTextContainer` is available since iOS 7

--- a/Tests/Tests.swift
+++ b/Tests/Tests.swift
@@ -19,66 +19,62 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
-
 import XCTest
 @testable import UITextView_Placeholder
 
 class Tests: XCTestCase {
-
+    
     var textView: UITextView!
-
+    
     // MARK: Setup
-
     override func setUp() {
         super.setUp()
         self.textView = UITextView()
     }
-
-
+    
+    
     // MARK: Basic Tests
-
     func testPlaceholder() {
         self.textView.placeholder = "Hello"
         XCTAssertEqual(self.textView.placeholderLabel.text, "Hello")
         self.textView.placeholder = nil
         XCTAssertEqual(self.textView.placeholderLabel.text, nil)
     }
-
+    
     func testAttributedPlaceholder() {
-        let attributedPlaceholder = attributedString("Hello", .bold(26))
+        let attributedPlaceholder = attributedString("Hello", .Bold(26))
         self.textView.attributedPlaceholder = attributedPlaceholder
         XCTAssertEqual(self.textView.attributedPlaceholder, attributedPlaceholder)
     }
-
-
+    
+    
     // MARK: Fonts
-
     func testSetFont_beforePlaceholder() {
-        self.textView.font = UIFont.systemFont(ofSize: 34)
+        self.textView.font = UIFont.systemFontOfSize(34)
         self.textView.placeholder = "Hello"
         XCTAssertEqual(self.textView.placeholderLabel.text, "Hello")
-        XCTAssertEqual(self.textView.placeholderLabel.font, UIFont.systemFont(ofSize: 34))
+        XCTAssertEqual(self.textView.placeholderLabel.font, UIFont.systemFontOfSize(34))
     }
-
+    
     func testSetFont_afterPlaceholder() {
         self.textView.placeholder = "Hello"
-        self.textView.font = UIFont.systemFont(ofSize: 34)
+        self.textView.font = UIFont.systemFontOfSize(34)
         XCTAssertEqual(self.textView.placeholderLabel.text, "Hello")
-        XCTAssertEqual(self.textView.placeholderLabel.font, UIFont.systemFont(ofSize: 34))
+        XCTAssertEqual(self.textView.placeholderLabel.font, UIFont.systemFontOfSize(34))
     }
-
+    
     func testSetFont_beforeAttributedPlaceholder() {
-        let attributedPlaceholder = attributedString("Hello", .bold(26))
-        self.textView.font = UIFont.systemFont(ofSize: 34)
+        let attributedPlaceholder = attributedString("Hello", .Bold(26))
+        self.textView.font = UIFont.systemFontOfSize(34)
         self.textView.attributedPlaceholder = attributedPlaceholder
         XCTAssertEqual(self.textView.attributedPlaceholder, attributedPlaceholder)
     }
-
+    
     func testSetFont_afterAttributedPlaceholderFont() {
-        let attributedPlaceholder = attributedString("Hello", .bold(26))
+        let attributedPlaceholder = attributedString("Hello", .Bold(26))
         self.textView.attributedPlaceholder = attributedPlaceholder
-        self.textView.font = UIFont.systemFont(ofSize: 34)
-        XCTAssertEqual(self.textView.attributedPlaceholder, attributedString("Hello", .normal(34)))
+        self.textView.font = UIFont.systemFontOfSize(34)
+        XCTAssertEqual(self.textView.attributedPlaceholder, attributedString("Hello", .Normal(34)))
     }
-
+    
 }

--- a/Tests/Tests.swift
+++ b/Tests/Tests.swift
@@ -45,7 +45,7 @@ class Tests: XCTestCase {
     }
 
     func testAttributedPlaceholder() {
-        let attributedPlaceholder = attributedString("Hello", .Bold(26))
+        let attributedPlaceholder = attributedString("Hello", .bold(26))
         self.textView.attributedPlaceholder = attributedPlaceholder
         XCTAssertEqual(self.textView.attributedPlaceholder, attributedPlaceholder)
     }
@@ -54,31 +54,31 @@ class Tests: XCTestCase {
     // MARK: Fonts
 
     func testSetFont_beforePlaceholder() {
-        self.textView.font = UIFont.systemFontOfSize(34)
+        self.textView.font = UIFont.systemFont(ofSize: 34)
         self.textView.placeholder = "Hello"
         XCTAssertEqual(self.textView.placeholderLabel.text, "Hello")
-        XCTAssertEqual(self.textView.placeholderLabel.font, UIFont.systemFontOfSize(34))
+        XCTAssertEqual(self.textView.placeholderLabel.font, UIFont.systemFont(ofSize: 34))
     }
 
     func testSetFont_afterPlaceholder() {
         self.textView.placeholder = "Hello"
-        self.textView.font = UIFont.systemFontOfSize(34)
+        self.textView.font = UIFont.systemFont(ofSize: 34)
         XCTAssertEqual(self.textView.placeholderLabel.text, "Hello")
-        XCTAssertEqual(self.textView.placeholderLabel.font, UIFont.systemFontOfSize(34))
+        XCTAssertEqual(self.textView.placeholderLabel.font, UIFont.systemFont(ofSize: 34))
     }
 
     func testSetFont_beforeAttributedPlaceholder() {
-        let attributedPlaceholder = attributedString("Hello", .Bold(26))
-        self.textView.font = UIFont.systemFontOfSize(34)
+        let attributedPlaceholder = attributedString("Hello", .bold(26))
+        self.textView.font = UIFont.systemFont(ofSize: 34)
         self.textView.attributedPlaceholder = attributedPlaceholder
         XCTAssertEqual(self.textView.attributedPlaceholder, attributedPlaceholder)
     }
 
     func testSetFont_afterAttributedPlaceholderFont() {
-        let attributedPlaceholder = attributedString("Hello", .Bold(26))
+        let attributedPlaceholder = attributedString("Hello", .bold(26))
         self.textView.attributedPlaceholder = attributedPlaceholder
-        self.textView.font = UIFont.systemFontOfSize(34)
-        XCTAssertEqual(self.textView.attributedPlaceholder, attributedString("Hello", .Normal(34)))
+        self.textView.font = UIFont.systemFont(ofSize: 34)
+        XCTAssertEqual(self.textView.attributedPlaceholder, attributedString("Hello", .normal(34)))
     }
 
 }

--- a/Tests/Utils.swift
+++ b/Tests/Utils.swift
@@ -19,22 +19,21 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
-
 import UIKit
 
 enum Font {
-    case normal(CGFloat)
-    case bold(CGFloat)
-
+    case Normal(CGFloat)
+    case Bold(CGFloat)
+    
     var font: UIFont {
         switch self {
-        case .normal(let size): return UIFont.systemFont(ofSize: size)
-        case .bold(let size): return UIFont.boldSystemFont(ofSize: size)
+        case .Normal(let size): return UIFont.systemFontOfSize(size)
+        case .Bold(let size): return UIFont.boldSystemFontOfSize(size)
         }
     }
 }
 
-func attributedString(_ string: String, _ font: Font) -> NSAttributedString {
+func attributedString(string: String, _ font: Font) -> NSAttributedString {
     let attributes = [NSFontAttributeName: font.font]
     return NSAttributedString(string: string, attributes: attributes)
 }

--- a/Tests/Utils.swift
+++ b/Tests/Utils.swift
@@ -23,18 +23,18 @@
 import UIKit
 
 enum Font {
-    case Normal(CGFloat)
-    case Bold(CGFloat)
+    case normal(CGFloat)
+    case bold(CGFloat)
 
     var font: UIFont {
         switch self {
-        case .Normal(let size): return UIFont.systemFontOfSize(size)
-        case .Bold(let size): return UIFont.boldSystemFontOfSize(size)
+        case .normal(let size): return UIFont.systemFont(ofSize: size)
+        case .bold(let size): return UIFont.boldSystemFont(ofSize: size)
         }
     }
 }
 
-func attributedString(string: String, _ font: Font) -> NSAttributedString {
+func attributedString(_ string: String, _ font: Font) -> NSAttributedString {
     let attributes = [NSFontAttributeName: font.font]
     return NSAttributedString(string: string, attributes: attributes)
 }

--- a/UITextView+Placeholder.xcodeproj/project.pbxproj
+++ b/UITextView+Placeholder.xcodeproj/project.pbxproj
@@ -20,7 +20,6 @@
 		0309F8F81CBCCD6500062D3B /* Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0309F8F71CBCCD6500062D3B /* Tests.swift */; };
 		0309F9001CBCCD8D00062D3B /* UITextView_Placeholder.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0309F8AD1CBCC7FF00062D3B /* UITextView_Placeholder.framework */; };
 		0309F9041CBCEE4700062D3B /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0309F9031CBCEE4700062D3B /* Utils.swift */; };
-		D0F91DA81DD4711600DC3CFB /* UITextView+Placeholder.m in Sources */ = {isa = PBXBuildFile; fileRef = 0309F8BC1CBCC84400062D3B /* UITextView+Placeholder.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -261,6 +260,7 @@
 					0309F8F41CBCCD6500062D3B = {
 						CreatedOnToolsVersion = 7.3;
 						LastSwiftMigration = 0810;
+						ProvisioningStyle = Automatic;
 					};
 				};
 			};
@@ -327,7 +327,6 @@
 				0309F8D01CBCC8A700062D3B /* ViewController.m in Sources */,
 				0309F8CD1CBCC8A700062D3B /* AppDelegate.m in Sources */,
 				0309F8CA1CBCC8A700062D3B /* main.m in Sources */,
-				D0F91DA81DD4711600DC3CFB /* UITextView+Placeholder.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -481,7 +480,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "kr.xoul.UITextView-Placeholder";
 				PRODUCT_NAME = UITextView_Placeholder;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 2.3;
 			};
 			name = Debug;
 		};
@@ -500,7 +499,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "kr.xoul.UITextView-Placeholder";
 				PRODUCT_NAME = UITextView_Placeholder;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 2.3;
 			};
 			name = Release;
 		};
@@ -531,24 +530,28 @@
 		0309F8FD1CBCCD6500062D3B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "Supporting Files/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = kr.xoul.Tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 2.3;
 			};
 			name = Debug;
 		};
 		0309F8FE1CBCCD6500062D3B /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "Supporting Files/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = kr.xoul.Tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 2.3;
 			};
 			name = Release;
 		};

--- a/UITextView+Placeholder.xcodeproj/project.pbxproj
+++ b/UITextView+Placeholder.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		0309F8F81CBCCD6500062D3B /* Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0309F8F71CBCCD6500062D3B /* Tests.swift */; };
 		0309F9001CBCCD8D00062D3B /* UITextView_Placeholder.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0309F8AD1CBCC7FF00062D3B /* UITextView_Placeholder.framework */; };
 		0309F9041CBCEE4700062D3B /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0309F9031CBCEE4700062D3B /* Utils.swift */; };
+		D0F91DA81DD4711600DC3CFB /* UITextView+Placeholder.m in Sources */ = {isa = PBXBuildFile; fileRef = 0309F8BC1CBCC84400062D3B /* UITextView+Placeholder.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -252,12 +253,14 @@
 				TargetAttributes = {
 					0309F8AC1CBCC7FF00062D3B = {
 						CreatedOnToolsVersion = 7.3;
+						LastSwiftMigration = 0810;
 					};
 					0309F8C51CBCC8A700062D3B = {
 						CreatedOnToolsVersion = 7.3;
 					};
 					0309F8F41CBCCD6500062D3B = {
 						CreatedOnToolsVersion = 7.3;
+						LastSwiftMigration = 0810;
 					};
 				};
 			};
@@ -324,6 +327,7 @@
 				0309F8D01CBCC8A700062D3B /* ViewController.m in Sources */,
 				0309F8CD1CBCC8A700062D3B /* AppDelegate.m in Sources */,
 				0309F8CA1CBCC8A700062D3B /* main.m in Sources */,
+				D0F91DA81DD4711600DC3CFB /* UITextView+Placeholder.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -477,6 +481,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "kr.xoul.UITextView-Placeholder";
 				PRODUCT_NAME = UITextView_Placeholder;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -495,6 +500,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "kr.xoul.UITextView-Placeholder";
 				PRODUCT_NAME = UITextView_Placeholder;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -530,6 +536,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = kr.xoul.Tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -541,6 +548,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = kr.xoul.Tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
The original KVO use runtime to hook UITextView’s dealloc method and
release. This method maybe cause a problem: When this category was
compile into a dynamic framework, and was used in other project which
also reference this category. In that case, the runtime hook two times,
and result is KVO not removed. This case can be reproduce in demo project: compile “UITextView+Placeholder.m” file in demo project and framework both.