### PR TITLE
Fixed ‘textView.font’ and ‘self.placeholderLabel.font’ fonts with dif…

### DIFF
--- a/Sources/UITextView+Placeholder.m
+++ b/Sources/UITextView+Placeholder.m
@@ -96,7 +96,6 @@
 
         self.needsUpdateFont = YES;
         [self updatePlaceholderLabel];
-        self.needsUpdateFont = NO;
 
         [[NSNotificationCenter defaultCenter] addObserver:self
                                                  selector:@selector(updatePlaceholderLabel)
@@ -180,6 +179,7 @@
         self.placeholderLabel.font = self.font;
         self.needsUpdateFont = NO;
     }
+  
     self.placeholderLabel.textAlignment = self.textAlignment;
 
     // `NSTextContainer` is available since iOS 7


### PR DESCRIPTION
The initial value of 'textView.text' is not empty. Then edit 'textView.text' to empty, the code for setting the font cannot be executed when updating the placeholders. This results in inconsistencies between 'textView.font' and 'self.placeholderLabel.font'.