### PR TITLE
Change placeholder UITextView background color to clearColor

### DIFF
--- a/Sources/UITextView+Placeholder.m
+++ b/Sources/UITextView+Placeholder.m
@@ -90,6 +90,7 @@
         self.attributedText = originalText;
 
         textView = [[UITextView alloc] init];
+        textView.backgroundColor = [UIColor clearColor];
         textView.textColor = [self.class defaultPlaceholderColor];
         textView.userInteractionEnabled = NO;
         objc_setAssociatedObject(self, @selector(placeholderTextView), textView, OBJC_ASSOCIATION_RETAIN_NONATOMIC);


### PR DESCRIPTION
Change background color to `clearColor` to avoid different background color with the original `UITextView`.