### PR TITLE
Add support for iOS SDK 13 (Xcode 11)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,21 @@
 language: objective-c
-osx_image: xcode9.3
+osx_image: xcode11
 sudo: false
 
 env:
   global:
+    - PROJECT="UITextView+Placeholder.xcodeproj"
     - SCHEME="UITextView+Placeholder"
-    - IOS_SDK="iphonesimulator11.3"
-    - DESTINATION="OS=11.3,name=iPhone X"
+  matrix:
+    - SDK="iphonesimulator11.4"      DESTINATION="platform=iOS Simulator,name=iPhone 8,OS=11.4"
+    - SDK="iphonesimulator12.4"      DESTINATION="platform=iOS Simulator,name=iPhone 8,OS=12.4"
+    - SDK="iphonesimulator13.0"      DESTINATION="platform=iOS Simulator,name=iPhone 8,OS=13.0"
 
 script:
-  - xcodebuild clean test -project "UITextView+Placeholder.xcodeproj" -scheme "$SCHEME" -sdk "$IOS_SDK" -destination "$DESTINATION" -configuration Release CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO | xcpretty -c
+  - xcodebuild clean test
+    -project "$PROJECT"
+    -scheme "$SCHEME"
+    -sdk "$SDK"
+    -destination "$DESTINATION"
+    -configuration Debug
+    CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO | xcpretty -c

--- a/Sources/UITextView+Placeholder.m
+++ b/Sources/UITextView+Placeholder.m
@@ -54,6 +54,9 @@
 #pragma mark `defaultPlaceholderColor`
 
 + (UIColor *)defaultPlaceholderColor {
+    if (@available(iOS 13, *)) {
+      return [UIColor placeholderTextColor];
+    }
     static UIColor *color = nil;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{

--- a/Sources/UITextView+Placeholder.m
+++ b/Sources/UITextView+Placeholder.m
@@ -59,7 +59,11 @@
     dispatch_once(&onceToken, ^{
         UITextField *textField = [[UITextField alloc] init];
         textField.placeholder = @" ";
-        color = [textField valueForKeyPath:@"_placeholderLabel.textColor"];
+        NSDictionary *attributes = [textField.attributedPlaceholder attributesAtIndex:0 effectiveRange:nil];
+        color = attributes[NSForegroundColorAttributeName];
+        if (!color) {
+          color = [UIColor colorWithRed:0 green:0 blue:0.0980392 alpha:0.22];
+        }
     });
     return color;
 }


### PR DESCRIPTION
* Fixes #61 and #63
* Also fixes #59
* Make it not use private API (`_placeholderLabel`). Instead, extract the default placeholder color from `attributedString`. (If failed, use hard coded value)
* Return `[UIColor placeholderTextColor]` in iOS 13.