### PR TITLE
Mirror lineFragmentPadding fix issue with wrong insets in iOS 13

### DIFF
--- a/Sources/UITextView+Placeholder.m
+++ b/Sources/UITextView+Placeholder.m
@@ -85,6 +85,7 @@
              @"text",
              @"textAlignment",
              @"textContainerInset",
+             @"textContainer.lineFragmentPadding",
              @"textContainer.exclusionPaths"];
 }
 
@@ -195,6 +196,7 @@
     }
     self.placeholderTextView.textContainer.exclusionPaths = self.textContainer.exclusionPaths;
     self.placeholderTextView.textContainerInset = self.textContainerInset;
+    self.placeholderTextView.textContainer.lineFragmentPadding = self.textContainer.lineFragmentPadding;
     self.placeholderTextView.frame = self.bounds;
 }
 


### PR DESCRIPTION
I was using below code to get zero padding for my `UITextView`

```
textView.textContainer.lineFragmentPadding = 0
textView.textContainerInset = .zero
```

Until iOS 12 I was fine. But with iOS 13 the placeholder got 5pt horizontal inset which is the default of [`lineFragmentPadding`](https://developer.apple.com/documentation/uikit/nstextcontainer/1444527-linefragmentpadding)

My PR adds the mirroring of the given value into the internal `placeholderTextView`