### PR TITLE
feat: use placeholder as accessibility value when placeholder is visible

### DIFF
--- a/Sources/UITextView+Placeholder.m
+++ b/Sources/UITextView+Placeholder.m
@@ -184,8 +184,10 @@
 - (void)updatePlaceholderTextView {
     if (self.text.length) {
         [self.placeholderTextView removeFromSuperview];
+        self.accessibilityValue = self.text;
     } else {
         [self insertSubview:self.placeholderTextView atIndex:0];
+        self.accessibilityValue = self.placeholder;
     }
 
     if (self.needsUpdateFont) {


### PR DESCRIPTION
Hi! Thank you for making this useful codes open source. 
I'm glad I found a small room for improvement in the code and be able to suggest a change.

Currently, VoiceOver users cannot access placeholder information.
Even tough placeholder textview shouldn't be "selectable" for voiceOver users as discussed in #57, its *information* still should be delivered to them.  

With this implementation, `UITextView+Placeholder` acts just like  `UITextField` in terms of VoiceOver experience.
